### PR TITLE
Fix case where implied volatility is outside the initial range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
         "format": "vendor/bin/php-cs-fixer fix --config .php_cs.dist.php --allow-risky=yes"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Black76.php
+++ b/src/Black76.php
@@ -118,7 +118,7 @@ class Black76
             $valueMin = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMin)['value'];
             $valueMax = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMax)['value'];
 
-            $volGuess = $volMin + ($marketPrice - $valueMin) * ($volMax - $volMin) / ($valueMax - $valueMin);
+            $volGuess = $volMin + ($marketPrice - $valueMin) * ($volMax - $volMin) / max($valueMax - $valueMin, $volMin);
             $valueGuess = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volGuess)['value'];
 
             if ($valueGuess < $marketPrice) {

--- a/tests/Black76Test.php
+++ b/tests/Black76Test.php
@@ -34,11 +34,15 @@ it('calculates implied volatility for PUT options when we know the value', funct
     $this->expect((new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 1.7398186455107651))->toEqualWithDelta(0.60, 0.00000000000001);
 });
 
-// Expections
-it('throws expection if we try to derive implied volatility using newton rapshon', function () {
+it('throws exception if implied volatility is outside the initial range', function () {
+    (new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 1);
+})->throws(RuntimeException::class);
+
+// Exceptions
+it('throws exception if we try to derive implied volatility using newton rapshon', function () {
     (new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 0.240, Black76::METHOD_NEWTON_RAPHSON);
 })->throws('Not implemented');
 
-it('throws expection if we try to derive implied volatility using wrong method', function () {
+it('throws exception if we try to derive implied volatility using wrong method', function () {
     (new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 0.240, 99);
 })->throws('Wrong method 99 or not supported');


### PR DESCRIPTION
Small fix for a potential divide by 0 error I received while testing. Thank you for this package!