### PR TITLE
Enforce upper and lower bounds for implied volatility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `options-calculator` will be documented in this file.
 
+## 1.0.2 - 2024-02-02
+
+- Enforce upper and lower bounds for implied volatility.
+
 ## 1.0.1 - 2024-02-02
 
 - Fix calculation when implied volatility is outside the initial range.

--- a/src/Black76.php
+++ b/src/Black76.php
@@ -128,7 +128,7 @@ class Black76
             $volBisection = $volMin + ($volMax - $volMin) * ($marketPrice - $valueMin) / ($valueMax - $valueMin);
 
             // If the true implied volatility is outside of the interval [0.00001;5], the condition below ensures that it will be set to the closest bound
-            $volGuess = max($volMin, min($volBisection, $volMax))
+            $volGuess = max($volMin, min($volBisection, $volMax));
             $valueGuess = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volGuess)['value'];
 
             if ($valueGuess < $marketPrice) {

--- a/src/Black76.php
+++ b/src/Black76.php
@@ -121,15 +121,14 @@ class Black76
         $valueMin = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMin)['value'];
         $valueMax = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMax)['value'];
 
-        if ($marketPrice < $valueMin || $marketPrice > $valueMax) {
-            throw new RuntimeException("Implied volatility could not be found in the range {$volMin} - {$volMax}.");
-        }
-
         while (++$i < $maxIterations && ($volMax - $volMin > $epsilon || $valueMin != $valueMax)) {
             $valueMin = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMin)['value'];
             $valueMax = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMax)['value'];
 
-            $volGuess = $volMin + ($marketPrice - $valueMin) * ($volMax - $volMin) / ($valueMax - $valueMin);
+            $volBisection = $volMin + ($volMax - $volMin) * ($marketPrice - $valueMin) / ($valueMax - $valueMin);
+
+            // If the true implied volatility is outside of the interval [0.00001;5], the condition below ensures that it will be set to the closest bound
+            $volGuess = max($volMin, min($volBisection, $volMax))
             $valueGuess = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volGuess)['value'];
 
             if ($valueGuess < $marketPrice) {

--- a/src/Black76.php
+++ b/src/Black76.php
@@ -124,7 +124,7 @@ class Black76
         while (++$i < $maxIterations && ($volMax - $volMin > $epsilon || $valueMin != $valueMax)) {
             $volBisection = $volMin + ($volMax - $volMin) * ($marketPrice - $valueMin) / ($valueMax - $valueMin);
 
-            // If the true implied volatility is outside of the interval [0.00001;5], the condition below ensures that it will be set to the closest bound
+            // If the true implied volatility is outside the interval [0.00001;5], the condition below ensures that it will be set to the closest bound
             $volGuess = max($volMin, min($volBisection, $volMax));
             $valueGuess = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volGuess)['value'];
 

--- a/src/Black76.php
+++ b/src/Black76.php
@@ -122,9 +122,6 @@ class Black76
         $valueMax = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMax)['value'];
 
         while (++$i < $maxIterations && ($volMax - $volMin > $epsilon || $valueMin != $valueMax)) {
-            $valueMin = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMin)['value'];
-            $valueMax = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMax)['value'];
-
             $volBisection = $volMin + ($volMax - $volMin) * ($marketPrice - $valueMin) / ($valueMax - $valueMin);
 
             // If the true implied volatility is outside of the interval [0.00001;5], the condition below ensures that it will be set to the closest bound
@@ -136,6 +133,9 @@ class Black76
             } else {
                 $volMax = $volGuess;
             }
+
+            $valueMin = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMin)['value'];
+            $valueMax = $this->getValues($type, $underlyingPrice, $strikePrice, $timeToMaturity, $volMax)['value'];
         }
 
         return $volGuess;

--- a/tests/Black76Test.php
+++ b/tests/Black76Test.php
@@ -34,9 +34,13 @@ it('calculates implied volatility for PUT options when we know the value', funct
     $this->expect((new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 1.7398186455107651))->toEqualWithDelta(0.60, 0.00000000000001);
 });
 
-it('throws exception if implied volatility is outside the initial range', function () {
-    (new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 1);
-})->throws(RuntimeException::class);
+it('returns an implied volatility of 0.00001 when the true value is below this lower bound', function () {
+    $this->expect((new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 1))->toEqualWithDelta(0.00001, 0.00000000000001);
+});
+
+it('returns an implied volatility of 5 when the true value is above this upper bound', function () {
+    $this->expect((new Black76())->getImpliedVolatility(Black76::PUT, 10.5, 12, 30 / 365.25, 10))->toEqualWithDelta(5, 0.00000000000001);
+});
 
 // Exceptions
 it('throws exception if we try to derive implied volatility using newton rapshon', function () {


### PR DESCRIPTION
## Description

Instead of raising an error when the true implied volatility is outside of the interval [0.00001;5], we now set the implied volatility equal to the interval's closest bound.